### PR TITLE
Feat exclude sponsored

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -1,3 +1,10 @@
+<?php
+
+// Get Sponsored cat ID
+$sponsored_cat = get_category_by_slug('sponsored');
+$sponsored_id = '-' . $sponsored_cat->cat_ID;
+
+?>
     <div id="pattern-space" class="theme-pattern-bg"></div>
     <footer id="footer" class="u-align-center font-condensed">
       <div class="container">
@@ -7,7 +14,14 @@
           </div>
           <div class="col s6">
             <ul>
-              <?php wp_list_categories(array('title_li' => '', 'orderby' => 'count', 'order' => 'DESC', 'hide_empty' => true)); ?>
+<?php 
+wp_list_categories( array(
+  'title_li' => '',
+  'orderby' => 'count', 
+  'order' => 'DESC', 
+  'hide_empty' => true,
+  'exclude'  => $sponsored_id,
+)); ?>
             </ul>
           </div>
           <div class="col s6">

--- a/front-page.php
+++ b/front-page.php
@@ -7,6 +7,11 @@ get_header();
 
 
 <?php
+
+// Get Sponsored cat ID
+$sponsored_cat = get_category_by_slug('sponsored');
+$sponsored_id = '-' . $sponsored_cat->cat_ID;
+
 // FEATURED: WP_Query arguments
 $args = array (
   'category_name'   => 'featured',
@@ -69,6 +74,7 @@ wp_reset_postdata();
 $args = array (
   'category_name'   => 'puta-portadazza',
   'posts_per_page'  => '1',
+  'cat'             => $sponsored_id,
 );
 
 // PORTADAZZA: The Query
@@ -120,6 +126,7 @@ wp_reset_postdata();
 $args = array (
   'category_name'   => 'noticias',
   'posts_per_page'  => '5',
+  'cat'             => $sponsored_id,
 );
 
 // NOTICIAS: The Query
@@ -182,10 +189,6 @@ echo IGV_get_option('_igv_ads_main_square_2');
 <?php
 // Build an array with the id of posts used in loops above here
 array_push($excluded_posts, $featured_id, $puta_id);
-
-// Get Sponsored cat ID
-$sponsored_cat = get_category_by_slug('sponsored');
-$sponsored_id = '-' . $sponsored_cat->cat_ID;
 
 // WP_Query arguments
 $args = array (

--- a/front-page.php
+++ b/front-page.php
@@ -180,12 +180,18 @@ echo IGV_get_option('_igv_ads_main_square_2');
 <?php get_template_part('partials/twitter'); ?><!-- Twitter feed -->
 
 <?php
-// WP_Query arguments
+// Build an array with the id of posts used in loops above here
 array_push($excluded_posts, $featured_id, $puta_id);
 
+// Get Sponsored cat ID
+$sponsored_cat = get_category_by_slug('sponsored');
+$sponsored_id = '-' . $sponsored_cat->cat_ID;
+
+// WP_Query arguments
 $args = array (
   'post__not_in'    => $excluded_posts,
   'posts_per_page'  => '16',
+  'cat'             => array( $sponsored_id ),
 );
 
 // The Query

--- a/front-page.php
+++ b/front-page.php
@@ -191,7 +191,7 @@ $sponsored_id = '-' . $sponsored_cat->cat_ID;
 $args = array (
   'post__not_in'    => $excluded_posts,
   'posts_per_page'  => '16',
-  'cat'             => array( $sponsored_id ),
+  'cat'             => $sponsored_id,
 );
 
 // The Query

--- a/front-page.php
+++ b/front-page.php
@@ -74,7 +74,7 @@ wp_reset_postdata();
 $args = array (
   'category_name'   => 'puta-portadazza',
   'posts_per_page'  => '1',
-  'cat'             => $sponsored_id,
+  'category__not_in' => $sponsored_id,
 );
 
 // PORTADAZZA: The Query
@@ -126,7 +126,7 @@ wp_reset_postdata();
 $args = array (
   'category_name'   => 'noticias',
   'posts_per_page'  => '5',
-  'cat'             => $sponsored_id,
+  'category__not_in' => $sponsored_id,
 );
 
 // NOTICIAS: The Query
@@ -194,7 +194,7 @@ array_push($excluded_posts, $featured_id, $puta_id);
 $args = array (
   'post__not_in'    => $excluded_posts,
   'posts_per_page'  => '16',
-  'cat'             => $sponsored_id,
+  'category__not_in' => $sponsored_id,
 );
 
 // The Query

--- a/header.php
+++ b/header.php
@@ -108,12 +108,24 @@ if ($radio_embed) {
     </div>
   </header>
 
+<?php
+
+// Get Sponsored cat ID
+$sponsored_cat = get_category_by_slug('sponsored');
+$sponsored_id = '-' . $sponsored_cat->cat_ID;
+
+?>
+
   <div id="drawer-categorias" class="header-drawer theme-grad-bg u-fc">
     <div class="container">
       <div class="row">
         <div class="col s24">
           <ul id="drawer-categorias-list" class="font-century-gothic">
-            <?php wp_list_categories(array('title_li' => '',)); ?>
+<?php 
+wp_list_categories( array(
+  'title_li' => '',
+  'exclude'  => $sponsored_id,
+)); ?>
           </ul>
         </div>
       </div>

--- a/index.php
+++ b/index.php
@@ -10,11 +10,9 @@ get_header();
 if( !is_search() ) {
   // Get Sponsored cat ID
   $sponsored_cat = get_category_by_slug('sponsored');
-  $sponsored_id = '-' . $sponsored_cat->cat_ID;
+  $sponsored_id = $sponsored_cat->cat_ID;
 
-  query_posts( array(
-    'cat' => $sponsored_id,
-  ));
+  query_posts($query_string . '&category__not_in=' . $sponsored_id);
 }
 
 // The Loop

--- a/index.php
+++ b/index.php
@@ -6,6 +6,17 @@ get_header();
 <main id="main-content">
 
 <?php
+// Exclude Sponsored posts, unless is search
+if( !is_search() ) {
+  // Get Sponsored cat ID
+  $sponsored_cat = get_category_by_slug('sponsored');
+  $sponsored_id = '-' . $sponsored_cat->cat_ID;
+
+  query_posts( array(
+    'cat' => $sponsored_id,
+  ));
+}
+
 // The Loop
 if ( have_posts() ) {
 ?>


### PR DESCRIPTION
This excludes the category `sponsored` from menu and footer.
Also excludes posts with this category from the home grid and archives.

The idea is that some sponsored content will be almost only promoted thru the ad spaces (internal ads) or the featured post in home page.
